### PR TITLE
Improve stop phrase handling in clinical assessment flow

### DIFF
--- a/src/services/clinicalAssessmentService.ts
+++ b/src/services/clinicalAssessmentService.ts
@@ -41,7 +41,7 @@ export interface ClinicalReport {
   recommendations: string[]
 }
 
-export type AssessmentStage = 
+export type AssessmentStage =
   | 'identification'
   | 'complaints_list'
   | 'main_complaint'
@@ -60,6 +60,42 @@ export class ClinicalAssessmentService {
   private currentAssessment: ClinicalAssessmentData | null = null
   private assessmentResponses: AssessmentResponse[] = []
 
+  private normalizeAnswer(answer: string): string {
+    return answer
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[!?.,]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+  }
+
+  private shouldStopAskingMore(answer: string): boolean {
+    const normalized = this.normalizeAnswer(answer)
+    if (!normalized) {
+      return false
+    }
+
+    const stopPatterns = [
+      'nao tenho mais',
+      'nao tem mais',
+      'nao lembro de mais',
+      'nao ha mais',
+      'so isso',
+      'so isso mesmo',
+      'somente isso',
+      'apenas isso',
+      'mais nada',
+      'nada mais',
+    ]
+
+    if (stopPatterns.some(pattern => normalized.includes(pattern))) {
+      return true
+    }
+
+    return normalized.includes('nao') && normalized.includes('mais')
+  }
+
   /**
    * Inicia nova avaliação clínica
    */
@@ -70,7 +106,7 @@ export class ClinicalAssessmentService {
       timestamp: new Date(),
       stage: 'identification',
       responses: [],
-      status: 'in_progress'
+      status: 'in_progress',
     }
 
     this.assessmentResponses = []
@@ -91,34 +127,39 @@ export class ClinicalAssessmentService {
     switch (stage) {
       case 'identification':
         if (responses.length === 0) {
-          return "Olá! Eu sou Nôa Esperanza. Por favor, apresente-se também e vamos iniciar a sua avaliação inicial para consultas com Dr. Ricardo Valença."
+          return 'Olá! Eu sou Nôa Esperanza. Por favor, apresente-se também e vamos iniciar a sua avaliação inicial para consultas com Dr. Ricardo Valença.'
         }
         if (responses.length === 1) {
-          return "O que trouxe você à nossa avaliação hoje?"
+          return 'O que trouxe você à nossa avaliação hoje?'
         }
         this.advanceStage()
         return this.getNextQuestion()
 
       case 'complaints_list':
         if (responses.filter(r => r.category === 'complaints').length === 0) {
-          return "O que trouxe você à nossa avaliação hoje?"
+          return 'O que trouxe você à nossa avaliação hoje?'
         }
-        const lastComplaintResponse = responses.filter(r => r.category === 'complaints').slice(-1)[0]
-        if (lastComplaintResponse && lastComplaintResponse.answer.toLowerCase().includes('não') && 
-            lastComplaintResponse.answer.toLowerCase().includes('mais')) {
+        const lastComplaintResponse = responses
+          .filter(r => r.category === 'complaints')
+          .slice(-1)[0]
+        if (lastComplaintResponse && this.shouldStopAskingMore(lastComplaintResponse.answer)) {
           this.advanceStage()
           return this.getNextQuestion()
         }
-        return "O que mais?"
+        return 'O que mais?'
 
       case 'main_complaint':
         const complaints = responses.filter(r => r.category === 'complaints').map(r => r.answer)
         return `De todas essas questões (${complaints.join(', ')}), qual mais o(a) incomoda?`
 
       case 'complaint_development':
-        const mainComplaint = responses.filter(r => r.category === 'complaints').slice(-1)[0]?.answer
-        const developmentResponses = responses.filter(r => r.category === 'complaints' && r.question.includes('Onde'))
-        
+        const mainComplaint = responses
+          .filter(r => r.category === 'complaints')
+          .slice(-1)[0]?.answer
+        const developmentResponses = responses.filter(
+          r => r.category === 'complaints' && r.question.includes('Onde')
+        )
+
         if (developmentResponses.length === 0) {
           return `Vamos explorar suas questões mais detalhadamente. Onde você sente ${mainComplaint}?`
         }
@@ -143,70 +184,72 @@ export class ClinicalAssessmentService {
       case 'medical_history':
         const historyResponses = responses.filter(r => r.category === 'history')
         if (historyResponses.length === 0) {
-          return "E agora, sobre o restante sua vida até aqui, desde seu nascimento, quais as questões de saúde que você já viveu? Vamos ordenar do mais antigo para o mais recente, o que veio primeiro?"
+          return 'E agora, sobre o restante sua vida até aqui, desde seu nascimento, quais as questões de saúde que você já viveu? Vamos ordenar do mais antigo para o mais recente, o que veio primeiro?'
         }
         const lastHistoryResponse = historyResponses.slice(-1)[0]
-        if (lastHistoryResponse && lastHistoryResponse.answer.toLowerCase().includes('não') && 
-            lastHistoryResponse.answer.toLowerCase().includes('mais')) {
+        if (lastHistoryResponse && this.shouldStopAskingMore(lastHistoryResponse.answer)) {
           this.advanceStage()
           return this.getNextQuestion()
         }
-        return "O que mais?"
+        return 'O que mais?'
 
       case 'family_history':
         const familyResponses = responses.filter(r => r.category === 'family')
         const maternalResponses = familyResponses.filter(r => r.question.includes('mãe'))
         const paternalResponses = familyResponses.filter(r => r.question.includes('pai'))
-        
+
         if (maternalResponses.length === 0) {
-          return "E na sua família? Começando pela parte de sua mãe, quais as questões de saúde dela e desse lado da família?"
+          return 'E na sua família? Começando pela parte de sua mãe, quais as questões de saúde dela e desse lado da família?'
         }
-        if (maternalResponses.length > 0 && maternalResponses.slice(-1)[0].answer.toLowerCase().includes('não') && 
-            maternalResponses.slice(-1)[0].answer.toLowerCase().includes('mais')) {
-          return "E por parte de seu pai?"
+        if (
+          maternalResponses.length > 0 &&
+          this.shouldStopAskingMore(maternalResponses.slice(-1)[0].answer)
+        ) {
+          return 'E por parte de seu pai?'
         }
-        if (paternalResponses.length > 0 && paternalResponses.slice(-1)[0].answer.toLowerCase().includes('não') && 
-            paternalResponses.slice(-1)[0].answer.toLowerCase().includes('mais')) {
+        if (
+          paternalResponses.length > 0 &&
+          this.shouldStopAskingMore(paternalResponses.slice(-1)[0].answer)
+        ) {
           this.advanceStage()
           return this.getNextQuestion()
         }
-        return "O que mais?"
+        return 'O que mais?'
 
       case 'lifestyle_habits':
         const habitResponses = responses.filter(r => r.category === 'habits')
         if (habitResponses.length === 0) {
-          return "Além dos hábitos de vida que já verificamos em nossa conversa, que outros hábitos você acha importante mencionar?"
+          return 'Além dos hábitos de vida que já verificamos em nossa conversa, que outros hábitos você acha importante mencionar?'
         }
         const lastHabitResponse = habitResponses.slice(-1)[0]
-        if (lastHabitResponse && lastHabitResponse.answer.toLowerCase().includes('não') && 
-            lastHabitResponse.answer.toLowerCase().includes('mais')) {
+        if (lastHabitResponse && this.shouldStopAskingMore(lastHabitResponse.answer)) {
           this.advanceStage()
           return this.getNextQuestion()
         }
-        return "O que mais?"
+        return 'O que mais?'
 
       case 'medications_allergies':
         const medResponses = responses.filter(r => r.category === 'medications')
         if (medResponses.length === 0) {
-          return "Você tem alguma alergia (mudança de tempo, medicação, poeira...)?"
+          return 'Você tem alguma alergia (mudança de tempo, medicação, poeira...)?'
         }
         if (medResponses.length === 1) {
-          return "Quais as medicações que você utiliza regularmente?"
+          return 'Quais as medicações que você utiliza regularmente?'
         }
         if (medResponses.length === 2) {
-          return "Quais as medicações você utiliza esporadicamente (de vez em quando) e porque utiliza?"
+          return 'Quais as medicações você utiliza esporadicamente (de vez em quando) e porque utiliza?'
         }
         this.advanceStage()
         return this.getNextQuestion()
 
       case 'review':
-        return "Vamos revisar a sua história para garantir que não perdemos nenhum detalhe importante."
+        return 'Vamos revisar a sua história para garantir que não perdemos nenhum detalhe importante.'
 
       case 'final_report':
         return this.generateFinalReport()
 
       default:
-        return "Avaliação concluída. Obrigada por sua participação!"
+        return 'Avaliação concluída. Obrigada por sua participação!'
     }
   }
 
@@ -222,7 +265,7 @@ export class ClinicalAssessmentService {
       question,
       answer,
       timestamp: new Date(),
-      category
+      category,
     }
 
     this.assessmentResponses.push(response)
@@ -246,7 +289,7 @@ export class ClinicalAssessmentService {
       'medications_allergies',
       'review',
       'final_report',
-      'completed'
+      'completed',
     ]
 
     const currentIndex = stages.indexOf(this.currentAssessment.stage)
@@ -259,7 +302,7 @@ export class ClinicalAssessmentService {
    * Gera relatório final
    */
   private generateFinalReport(): string {
-    if (!this.currentAssessment) return ""
+    if (!this.currentAssessment) return ''
 
     const complaints = this.assessmentResponses.filter(r => r.category === 'complaints')
     const history = this.assessmentResponses.filter(r => r.category === 'history')
@@ -269,17 +312,30 @@ export class ClinicalAssessmentService {
 
     const patientName = this.assessmentResponses[0]?.answer || 'Não informado'
     const mainComplaint = complaints.slice(-1)[0]?.answer || ''
-    const maternal = family.filter(f => f.question.includes('mãe')).map(f => f.answer).join(', ')
-    const paternal = family.filter(f => f.question.includes('pai')).map(f => f.answer).join(', ')
-    const regularMeds = medications.filter(m => m.question.includes('regularmente')).map(m => m.answer).join(', ')
-    const sporadicMeds = medications.filter(m => m.question.includes('esporadicamente')).map(m => m.answer).join(', ')
-    const allergies = medications.filter(m => m.question.includes('alergia')).map(m => m.answer).join(', ')
+    const maternal = family
+      .filter(f => f.question.includes('mãe'))
+      .map(f => f.answer)
+      .join(', ')
+    const paternal = family
+      .filter(f => f.question.includes('pai'))
+      .map(f => f.answer)
+      .join(', ')
+    const regularMeds = medications
+      .filter(m => m.question.includes('regularmente'))
+      .map(m => m.answer)
+      .join(', ')
+    const sporadicMeds = medications
+      .filter(m => m.question.includes('esporadicamente'))
+      .map(m => m.answer)
+      .join(', ')
+    const allergies = medications
+      .filter(m => m.question.includes('alergia'))
+      .map(m => m.answer)
+      .join(', ')
 
     const narrative = [
       `Este é o relatório da Avaliação Clínica Inicial de ${patientName}.`,
-      mainComplaint
-        ? `A queixa que mais o(a) incomoda é: ${mainComplaint}.`
-        : '',
+      mainComplaint ? `A queixa que mais o(a) incomoda é: ${mainComplaint}.` : '',
       complaints.length > 0
         ? `Ao explorar a história atual, o(a) paciente relatou: ${complaints.map(c => c.answer).join('; ')}.`
         : '',
@@ -292,33 +348,40 @@ export class ClinicalAssessmentService {
       habits.length > 0
         ? `Quanto aos hábitos de vida, citou: ${habits.map(h => h.answer).join('; ')}.`
         : '',
-      (regularMeds || sporadicMeds || allergies)
+      regularMeds || sporadicMeds || allergies
         ? `Alergias: ${allergies || 'não referidas'}. Medicações em uso: regulares (${regularMeds || 'não referidas'}) e esporádicas (${sporadicMeds || 'não referidas'}).`
-        : ''
-    ].filter(Boolean).join('\n\n')
+        : '',
+    ]
+      .filter(Boolean)
+      .join('\n\n')
 
     this.currentAssessment.finalReport = {
       patientName,
       mainComplaint: complaints[0]?.answer || '',
       complaintsList: complaints.map(c => c.answer),
-      developmentDetails: complaints.filter(c => c.question.toLowerCase().includes('onde')).map(c => c.answer).join(', '),
+      developmentDetails: complaints
+        .filter(c => c.question.toLowerCase().includes('onde'))
+        .map(c => c.answer)
+        .join(', '),
       medicalHistory: history.map(h => h.answer),
       familyHistory: {
         maternal: family.filter(f => f.question.includes('mãe')).map(f => f.answer),
-        paternal: family.filter(f => f.question.includes('pai')).map(f => f.answer)
+        paternal: family.filter(f => f.question.includes('pai')).map(f => f.answer),
       },
       lifestyleHabits: habits.map(h => h.answer),
       medications: {
         regular: medications.filter(m => m.question.includes('regularmente')).map(m => m.answer),
-        sporadic: medications.filter(m => m.question.includes('esporadicamente')).map(m => m.answer)
+        sporadic: medications
+          .filter(m => m.question.includes('esporadicamente'))
+          .map(m => m.answer),
       },
       allergies: medications.filter(m => m.question.includes('alergia')).map(m => m.answer),
       summary: `RELATÓRIO DE AVALIAÇÃO CLÍNICA INICIAL\n\n${narrative}\n\nEsta é uma avaliação inicial segundo o método do Dr. Ricardo Valença para aperfeiçoar o atendimento.`,
       recommendations: [
         'Agendar consulta com Dr. Ricardo Valença',
         'Manter acompanhamento regular',
-        'Seguir orientações médicas'
-      ]
+        'Seguir orientações médicas',
+      ],
     }
 
     return this.currentAssessment.finalReport.summary
@@ -334,7 +397,7 @@ export class ClinicalAssessmentService {
 
     // Simular geração de NFT
     const nftHash = `nft_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
-    
+
     this.currentAssessment.nftHash = nftHash
     this.currentAssessment.status = 'completed'
 
@@ -346,9 +409,11 @@ export class ClinicalAssessmentService {
         session_id: this.currentAssessment.id,
         status: 'completed',
         etapa_atual: this.currentAssessment.stage,
-        dados: this.currentAssessment.finalReport ? JSON.stringify(this.currentAssessment.finalReport) : null,
+        dados: this.currentAssessment.finalReport
+          ? JSON.stringify(this.currentAssessment.finalReport)
+          : null,
         created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       }
       await supabase.from('avaliacoes_iniciais').upsert(payload, { onConflict: 'id' })
     } catch (e) {
@@ -361,7 +426,7 @@ export class ClinicalAssessmentService {
 
     return {
       report: this.currentAssessment.finalReport,
-      nftHash
+      nftHash,
     }
   }
 
@@ -386,7 +451,7 @@ export class ClinicalAssessmentService {
       totalAssessments: this.currentAssessment ? 1 : 0,
       completedAssessments: this.currentAssessment?.status === 'completed' ? 1 : 0,
       averageDuration: 18, // minutos
-      currentStage: this.currentAssessment?.stage || 'none'
+      currentStage: this.currentAssessment?.stage || 'none',
     }
   }
 }


### PR DESCRIPTION
## Summary
- normalize patient answers before processing the clinical assessment flow
- add stop phrase detection for expressions like "só isso" and "mais nada"
- reuse the improved detection to end "O que mais?" prompts across the script stages

## Testing
- npm run lint:staged
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e4b13715588332b73b2afbc2f7af4f